### PR TITLE
Add `Depends: R (>= 3.5.0)` to avoid R CMD build warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,8 @@ BugReports: https://github.com/keaven/gsDesignNB/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
+Depends:
+    R (>= 3.5.0)
 Imports:
     data.table,
     gsDesign,


### PR DESCRIPTION
As title suggests, since the (newer) `.rds` serialization format version requires R >= 3.5.0 to parse.