### PR TITLE
Refactor vignettes to replace `cat()` with `message()`

### DIFF
--- a/vignettes/completers-interim-example.Rmd
+++ b/vignettes/completers-interim-example.Rmd
@@ -7,14 +7,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r setup}
+```{r, message=FALSE, warning=FALSE}
 library(gsDesignNB)
 library(gsDesign)
 library(data.table)
@@ -164,10 +164,10 @@ info_asymp_final <- compute_info_at_time(
   dropout_rate = dropout_rate$rate[1]
 )
 
-cat("Asymptotic Information (Interim):", round(info_asymp_interim, 2), "\n")
-cat("Mean Simulated Information (Interim):", round(mean(results$interim_info), 2), "\n")
-cat("Asymptotic Information (Final):", round(info_asymp_final, 2), "\n")
-cat("Mean Simulated Information (Final):", round(mean(results$final_info), 2), "\n")
+message("Asymptotic Information (Interim): ", round(info_asymp_interim, 2))
+message("Mean Simulated Information (Interim): ", round(mean(results$interim_info), 2))
+message("Asymptotic Information (Final): ", round(info_asymp_final, 2))
+message("Mean Simulated Information (Final): ", round(mean(results$final_info), 2))
 ```
 
 ## Results summary
@@ -185,7 +185,7 @@ Comparison of Z-scores at Interim vs Final Analysis.
 ```{r plot, fig.width=6, fig.height=6}
 # Correlation between interim and final Z-scores
 cor_z <- cor(results$interim_z, results$final_z)
-cat("Correlation between interim and final Z-scores:", round(cor_z, 3), "\n")
+message("Correlation between interim and final Z-scores: ", round(cor_z, 3))
 
 ggplot(results, aes(x = interim_z, y = final_z)) +
   geom_point(alpha = 0.7) +
@@ -254,5 +254,5 @@ for (i in 1:n_sims) {
   }
 }
 
-cat("Power (Empirical Rejection Rate):", mean(reject), "\n")
+message("Power (Empirical Rejection Rate): ", mean(reject))
 ```

--- a/vignettes/group-sequential-simulation.Rmd
+++ b/vignettes/group-sequential-simulation.Rmd
@@ -7,14 +7,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r setup}
+```{r, message=FALSE, warning=FALSE}
 library(gsDesign)
 library(gsDesignNB)
 library(data.table)
@@ -72,7 +72,7 @@ nb_ss <- sample_size_nbinom(
 )
 
 # Print key results
-cat("Fixed design\n")
+message("Fixed design")
 nb_ss
 ```
 
@@ -507,11 +507,11 @@ futility_by_sim <- as.data.table(all_results)[
 
 overall_futility <- mean(futility_by_sim$futility, na.rm = TRUE)
 
-cat("\n=== Overall Operating Characteristics ===\n")
-cat(sprintf("Number of simulations: %d\n", n_sims))
-cat(sprintf("Overall Power (P[reject H0]): %.1f%%\n", overall_power * 100))
-cat(sprintf("Futility Stopping Rate: %.1f%%\n", overall_futility * 100))
-cat(sprintf("Design Power (target): %.1f%%\n", (1 - gs_nb$beta) * 100))
+message("=== Overall Operating Characteristics ===")
+message(sprintf("Number of simulations: %d", n_sims))
+message(sprintf("Overall Power (P[reject H0]): %.1f%%", overall_power * 100))
+message(sprintf("Futility Stopping Rate: %.1f%%", overall_futility * 100))
+message(sprintf("Design Power (target): %.1f%%", (1 - gs_nb$beta) * 100))
 ```
 
 ### Visualization of Z-statistics

--- a/vignettes/sample-size-nbinom.Rmd
+++ b/vignettes/sample-size-nbinom.Rmd
@@ -8,14 +8,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r setup}
+```{r, message=FALSE, warning=FALSE}
 library(gsDesignNB)
 ```
 

--- a/vignettes/seasonal-simulation.Rmd
+++ b/vignettes/seasonal-simulation.Rmd
@@ -7,14 +7,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r setup}
+```{r, message=FALSE, warning=FALSE}
 library(gsDesignNB)
 library(data.table)
 library(dplyr)
@@ -162,8 +162,8 @@ print(coef_summary)
 
 # Estimated Rate Ratio (Experimental / Control)
 rr <- exp(coef(fit)["treatmentExperimental"])
-cat("Estimated Rate Ratio (Experimental / Control):", round(rr, 3), "\n")
-cat("True Design Rate Ratio:", 0.7, "\n")
+message("Estimated Rate Ratio (Experimental / Control): ", round(rr, 3))
+message("True Design Rate Ratio: ", 0.7)
 ```
 
 ### Variance and information
@@ -173,9 +173,9 @@ The variance of the treatment effect estimate can be extracted from the covarian
 ```{r information}
 # Variance of the treatment effect coefficient
 var_beta <- vcov(fit)["treatmentExperimental", "treatmentExperimental"]
-cat("Variance of Treatment Effect (log-scale):", var_beta, "\n")
+message("Variance of Treatment Effect (log-scale): ", var_beta)
 
 # Statistical Information
 info <- 1 / var_beta
-cat("Statistical Information:", info, "\n")
+message("Statistical Information: ", info)
 ```

--- a/vignettes/simulation-example.Rmd
+++ b/vignettes/simulation-example.Rmd
@@ -8,14 +8,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r setup}
+```{r, message=FALSE, warning=FALSE}
 library(gsDesignNB)
 library(data.table)
 library(ggplot2)

--- a/vignettes/verification-simulation.Rmd
+++ b/vignettes/verification-simulation.Rmd
@@ -7,14 +7,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r setup}
+```{r, message=FALSE, warning=FALSE}
 library(gsDesignNB)
 library(data.table)
 library(ggplot2)


### PR DESCRIPTION
This PR replaced vignette "status/progress" `cat()` usage with `message()` so they can be suppressed via `suppressMessages()` / handled cleanly by knitr. Left `cat()` used in `print` methods under `R/` unchanged since printing is their primary purpose.

Also, added `message=FALSE, warning=FALSE` chunk options to package-attaching code chunks in vignettes to suppress unnecessary messages and warnings during vignette rendering.