### PR TITLE
Run `usethis::use_coverage()` to make coverage informational

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^\.\.Rcheck$
 ^\.Rhistory$
 \.DS_Store$
+^codecov\.yml$

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
This PR runs `usethis::use_coverage()` to add `codecov.yml` which makes code coverage informational - avoids Codecov from adding comments about coverage changes in every pull request.