### PR TITLE
Add `AGENTS.md`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^\.Rhistory$
 \.DS_Store$
 ^codecov\.yml$
+^AGENTS\.md$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,42 +1,48 @@
-# GitHub Copilot Instructions for gsDesignNB
+# AGENTS.md
 
-## Project Overview
+## Project overview
+
 `gsDesignNB` is an R package for designing and simulating clinical trials with negative binomial outcomes (recurrent events). It integrates with the `gsDesign` package to support group sequential designs.
 
-## Architecture & Key Components
-- **Core Logic (`R/`)**:
+## Architecture & key components
+
+- **Core logic (`R/`)**:
   - `sample_size_nbinom.R`: Fixed design sample size calculations.
   - `sim_gs_nbinom.R`: Group sequential design simulations.
   - `nb_sim.R`: Underlying data generation for simulations.
-- **Data Handling**: Uses `data.table` for high-performance data manipulation in simulations.
+- **Data handling**: Uses `data.table` for high-performance data manipulation in simulations.
 - **Integration**: Re-exports `gsDesign` functions (`reexport-gsDesign.R`) to extend its functionality seamlessly.
 
-## Development Workflow
-- **Package Management**: Standard R package structure.
-- **Build & Reload**: Use `devtools::load_all()` for interactive development.
-- **Testing**: Run tests with `devtools::test()` or `testthat::test_dir("tests/testthat")`.
+## Development workflow
+
+- **Package management**: Standard R package structure.
+- **Build & reload**: Use `devtools::load_all()` for interactive development.
+- **Testing**: Run tests with `devtools::test()`.
 - **Documentation**: Generate documentation with `devtools::document()`. The site is built with `pkgdown`.
 
-## Coding Standards & Patterns
+## Coding standards & patterns
+
 - **Style**: Follows the [tidyverse style guide](https://style.tidyverse.org/).
-- **Data Manipulation**:
+- **Data manipulation**:
   - Prefer `data.table` syntax (`dt[i, j, by]`) inside internal functions for performance, especially in simulation loops.
   - Use `utils::globalVariables()` in `R/globals.R` to handle `data.table` non-standard evaluation warnings.
 - **Documentation**: Use `roxygen2` with Markdown support.
   - Include `@examples` that are runnable.
   - Use `@importFrom` to manage dependencies explicitly.
-- **Error Handling**: Validate inputs early in exported functions (e.g., check for positive rates, valid probabilities).
+- **Error handling**: Validate inputs early in exported functions (e.g., check for positive rates, valid probabilities).
 
-## Testing Guidelines
+## Testing guidelines
+
 - **Framework**: Uses `testthat` (Edition 3).
 - **Structure**: Tests are located in `tests/testthat/` and prefixed with `test-`.
-- **Best Practices**:
+- **Best practices**:
   - Test against known theoretical results (e.g., Poisson limit when dispersion is 0).
   - Verify S3 class structures and return types.
   - Use `expect_error` to verify input validation.
   - Example: See `tests/testthat/test-sample_size_nbinom.R` for testing calculation logic.
 
-## Common Tasks
+## Common tasks
+
 - **Adding a new simulation feature**:
   1. Update `nb_sim.R` or `nb_sim_seasonal.R` to generate the new data structure.
   2. Update `sim_gs_nbinom.R` to handle the new data in the simulation loop.


### PR DESCRIPTION
This PR moves the GitHub Copilot-specific `.github/copilot-instructions.md` into `AGENTS.md` (standard coding agent guide format) and adds it to `.Rbuildignore`.