### PR TITLE
Improve unit test coverage to 95%

### DIFF
--- a/R/preview_pkgdown_site.R
+++ b/R/preview_pkgdown_site.R
@@ -23,7 +23,7 @@
 #' }
 #'
 #' @export
-preview_pkgdown_site <- function(port = 8787L) {
+preview_pkgdown_site <- function(port = 8787L) { # nocov start
   docs <- file.path(getwd(), "docs")
   if (!dir.exists(docs)) {
     stop(
@@ -43,4 +43,4 @@ preview_pkgdown_site <- function(port = 8787L) {
     background = FALSE
   )
   invisible(NULL)
-}
+} # nocov end

--- a/R/run_ssr_shiny.R
+++ b/R/run_ssr_shiny.R
@@ -18,7 +18,7 @@
 #' }
 #'
 #' @export
-run_ssr_shiny <- function(
+run_ssr_shiny <- function( # nocov start
   display.mode = c("normal", "showcase"),
   launch.browser = interactive()
 ) {
@@ -52,4 +52,4 @@ run_ssr_shiny <- function(
     display.mode = display.mode,
     launch.browser = launch.browser
   )
-}
+} # nocov end

--- a/tests/testthat/test-calculate_blinded_info.R
+++ b/tests/testthat/test-calculate_blinded_info.R
@@ -55,3 +55,48 @@ test_that("calculate_blinded_info blends allocation into Fisher weights", {
   expect_true(is.finite(res_two_to_one$blinded_info))
   expect_gt(res_equal$blinded_info, res_two_to_one$blinded_info)
 })
+
+test_that("calculate_blinded_info errors on missing columns", {
+  bad <- data.frame(x = 1, y = 2)
+  expect_error(
+    calculate_blinded_info(bad, lambda1_planning = 0.5, lambda2_planning = 0.3),
+    "events.*tte"
+  )
+})
+
+test_that("calculate_blinded_info returns zero for all-zero exposure", {
+  df <- data.frame(events = c(0, 0), tte = c(0, 0))
+  res <- calculate_blinded_info(
+    df, ratio = 1, lambda1_planning = 0.5, lambda2_planning = 0.3
+  )
+  expect_equal(res$blinded_info, 0)
+  expect_true(is.na(res$dispersion_blinded))
+})
+
+test_that("calculate_blinded_info handles event_gap adjustment", {
+  df <- data.frame(tte = rep(1, 50), events = rpois(50, 2))
+
+  res_no_gap <- calculate_blinded_info(
+    df, ratio = 1, lambda1_planning = 0.5, lambda2_planning = 0.3
+  )
+
+  res_gap <- calculate_blinded_info(
+    df, ratio = 1, lambda1_planning = 0.5, lambda2_planning = 0.3,
+    event_gap = 0.3
+  )
+
+  expect_true(is.finite(res_no_gap$blinded_info))
+  expect_true(is.finite(res_gap$blinded_info))
+  # The gap-adjusted rate ratio differs, so information may change
+  expect_false(isTRUE(all.equal(res_no_gap$blinded_info, res_gap$blinded_info)))
+})
+
+test_that("calculate_blinded_info falls back to Poisson on NB failure", {
+  # Very few observations, NB fit may fail
+  df <- data.frame(events = c(0, 0, 1), tte = c(0.01, 0.01, 0.01))
+  res <- suppressWarnings(
+    calculate_blinded_info(df, ratio = 1, lambda1_planning = 0.5, lambda2_planning = 0.3)
+  )
+  # Should still produce a result
+  expect_true(is.numeric(res$blinded_info))
+})

--- a/tests/testthat/test-check_gs_bound.R
+++ b/tests/testthat/test-check_gs_bound.R
@@ -1,0 +1,119 @@
+test_that("check_gs_bound returns correct structure", {
+  design <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 2, timing = c(0.5, 1))
+  sim_df <- data.frame(
+    sim = c(1, 1, 2, 2),
+    analysis = c(1, 2, 1, 2),
+    z_stat = c(2.5, NA, -0.2, 2.2),
+    blinded_info = c(50, 100, 50, 100),
+    unblinded_info = c(50, 100, 50, 100)
+  )
+
+  result <- check_gs_bound(sim_df, design)
+
+  expect_true(is.data.frame(result))
+  expect_true("cross_upper" %in% names(result))
+  expect_true("cross_lower" %in% names(result))
+  expect_true("cross_harm" %in% names(result))
+
+  # Same number of rows
+ expect_equal(nrow(result), nrow(sim_df))
+})
+
+test_that("check_gs_bound detects upper crossings", {
+  design <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 2, timing = c(0.5, 1))
+  # Large z should cross upper bound
+  sim_df <- data.frame(
+    sim = c(1, 1),
+    analysis = c(1, 2),
+    z_stat = c(5.0, NA),
+    blinded_info = c(50, 100),
+    unblinded_info = c(50, 100)
+  )
+
+  result <- check_gs_bound(sim_df, design)
+  expect_true(result$cross_upper[1])
+})
+
+test_that("check_gs_bound detects lower crossings for test.type >= 2", {
+  design <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 4, timing = c(0.5, 1))
+  # Very negative z should cross lower bound
+  sim_df <- data.frame(
+    sim = c(1, 1),
+    analysis = c(1, 2),
+    z_stat = c(-5.0, NA),
+    blinded_info = c(50, 100),
+    unblinded_info = c(50, 100)
+  )
+
+  result <- check_gs_bound(sim_df, design)
+  expect_true(result$cross_lower[1])
+})
+
+test_that("check_gs_bound errors on bad design", {
+  sim_df <- data.frame(
+    sim = 1, analysis = 1, z_stat = 1.5,
+    blinded_info = 50, unblinded_info = 50
+  )
+  expect_error(check_gs_bound(sim_df, list(n.fix = 100)), "gsDesign or gsNB")
+})
+
+test_that("check_gs_bound errors on missing z_stat", {
+  design <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 1)
+  sim_df <- data.frame(sim = c(1, 1), analysis = c(1, 2), blinded_info = c(50, 100), unblinded_info = c(50, 100))
+  expect_error(check_gs_bound(sim_df, design), "z_stat")
+})
+
+test_that("check_gs_bound errors on missing info column", {
+  design <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 1)
+  sim_df <- data.frame(sim = c(1, 1), analysis = c(1, 2), z_stat = c(2.0, 1.0))
+  expect_error(check_gs_bound(sim_df, design), "blinded_info")
+})
+
+test_that("check_gs_bound accepts custom info_col", {
+  design <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 2, timing = c(0.5, 1))
+  sim_df <- data.frame(
+    sim = c(1, 1),
+    analysis = c(1, 2),
+    z_stat = c(1.0, 2.0),
+    blinded_info = c(50, 100),
+    unblinded_info = c(50, 100)
+  )
+
+  result <- check_gs_bound(sim_df, design, info_col = "unblinded_info")
+  expect_true(is.data.frame(result))
+  expect_true("cross_upper" %in% names(result))
+})
+
+test_that("check_gs_bound handles NA z_stat gracefully", {
+  design <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 2, timing = c(0.5, 1))
+  sim_df <- data.frame(
+    sim = c(1, 1),
+    analysis = c(1, 2),
+    z_stat = c(NA_real_, NA_real_),
+    blinded_info = c(50, 100),
+    unblinded_info = c(50, 100)
+  )
+
+  result <- check_gs_bound(sim_df, design)
+  expect_false(any(result$cross_upper))
+  expect_false(any(result$cross_lower))
+})
+
+test_that("check_gs_bound works with multiple simulations", {
+  design <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 2, timing = c(0.5, 1))
+  sim_df <- data.frame(
+    sim = c(1, 1, 2, 2, 3, 3),
+    analysis = c(1, 2, 1, 2, 1, 2),
+    z_stat = c(5.0, NA, 0.5, 1.0, -5.0, NA),
+    blinded_info = c(50, 100, 50, 100, 50, 100),
+    unblinded_info = c(50, 100, 50, 100, 50, 100)
+  )
+
+  result <- check_gs_bound(sim_df, design)
+  expect_equal(nrow(result), 6)
+
+  # Sim 1: crosses upper at analysis 1
+  expect_true(result$cross_upper[result$sim == 1 & result$analysis == 1])
+  # Sim 3: crosses lower at analysis 1
+  expect_true(result$cross_lower[result$sim == 3 & result$analysis == 1])
+})

--- a/tests/testthat/test-cut_completers.R
+++ b/tests/testthat/test-cut_completers.R
@@ -84,3 +84,13 @@ test_that("cut_date_for_completers works with nb_sim_seasonal output", {
   expect_true(is.numeric(d10))
   expect_true(is.finite(d10))
 })
+
+test_that("cut_date_for_completers errors on missing columns", {
+  # Missing follow-up column
+  bad1 <- data.frame(id = 1, treatment = "A", enroll_time = 0)
+  expect_error(cut_date_for_completers(bad1, 1), "follow-up time column")
+
+  # Missing id column
+  bad2 <- data.frame(tte = 1, treatment = "A", enroll_time = 0)
+  expect_error(cut_date_for_completers(bad2, 1), "id")
+})

--- a/tests/testthat/test-cut_data_by_date.R
+++ b/tests/testthat/test-cut_data_by_date.R
@@ -18,3 +18,124 @@ test_that("cut_data_by_date truncates follow-up", {
   expect_true(all(cut$tte <= 0.5))
   expect_true(all(cut$events >= 0))
 })
+
+test_that("cut_data_by_date.default errors on unsupported class", {
+  dummy <- data.frame(x = 1)
+  class(dummy) <- "unsupported_class"
+  expect_error(cut_data_by_date(dummy, cut_date = 1), "No cut_data_by_date")
+})
+
+test_that("cut_data_by_date.nb_sim_data errors on invalid cut_date", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(treatment = "A", rate = 0.5)
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 1, n = 5, block = "A")
+
+  expect_error(cut_data_by_date(sim, cut_date = NULL), "single finite numeric")
+  expect_error(cut_data_by_date(sim, cut_date = Inf), "single finite numeric")
+  expect_error(cut_data_by_date(sim, cut_date = c(1, 2)), "single finite numeric")
+})
+
+test_that("cut_data_by_date.nb_sim_data returns empty for early cut", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(treatment = "A", rate = 0.5)
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 1, n = 5, block = "A")
+
+  # Cut before anyone enrolls
+  cut <- cut_data_by_date(sim, cut_date = 0)
+  expect_equal(nrow(cut), 0)
+  expect_true(all(c("id", "treatment", "enroll_time", "tte", "tte_total", "events") %in% names(cut)))
+})
+
+test_that("cut_data_by_date.nb_sim_data works with function gap", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(treatment = "A", rate = 0.5)
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 2, n = 10, block = "A")
+
+  # Function-based gap
+  cut_func <- cut_data_by_date(sim, cut_date = 1, event_gap = function() 0.1)
+  cut_fixed <- cut_data_by_date(sim, cut_date = 1, event_gap = 0.1)
+
+  # Both should produce valid output
+  expect_true(nrow(cut_func) > 0)
+  expect_true(all(cut_func$events >= 0))
+})
+
+test_that("cut_data_by_date.nb_sim_seasonal works", {
+  enroll_rate <- data.frame(rate = 20 / (5 / 12), duration = 5 / 12)
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = c(0.6, 0.5, 0.4, 0.5, 0.4, 0.3, 0.2, 0.3)
+  )
+  sim <- nb_sim_seasonal(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    max_followup = 1,
+    randomization_start_date = as.Date("2020-01-01"),
+    n = 20
+  )
+
+  cut <- cut_data_by_date(sim, cut_date = 0.5)
+  expect_true(is.data.frame(cut))
+  expect_true(all(c("id", "treatment", "season", "tte", "events") %in% names(cut)))
+})
+
+test_that("cut_data_by_date.nb_sim_seasonal errors on invalid cut_date", {
+  enroll_rate <- data.frame(rate = 20 / (5 / 12), duration = 5 / 12)
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = rep(0.5, 8)
+  )
+  sim <- nb_sim_seasonal(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    max_followup = 1,
+    randomization_start_date = as.Date("2020-01-01"),
+    n = 10
+  )
+
+  expect_error(cut_data_by_date(sim, cut_date = NULL), "single finite numeric")
+})
+
+test_that("cut_data_by_date.nb_sim_seasonal returns empty for early cut", {
+  enroll_rate <- data.frame(rate = 20 / (5 / 12), duration = 5 / 12)
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = rep(0.5, 8)
+  )
+  sim <- nb_sim_seasonal(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    max_followup = 1,
+    randomization_start_date = as.Date("2020-01-01"),
+    n = 10
+  )
+
+  cut <- cut_data_by_date(sim, cut_date = 0)
+  expect_equal(nrow(cut), 0)
+  expect_true("season" %in% names(cut))
+})
+
+test_that("cut_data_by_date.nb_sim_seasonal handles event_gap", {
+  enroll_rate <- data.frame(rate = 20 / (5 / 12), duration = 5 / 12)
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = c(0.6, 0.5, 0.4, 0.5, 0.4, 0.3, 0.2, 0.3)
+  )
+  sim <- nb_sim_seasonal(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    max_followup = 1,
+    randomization_start_date = as.Date("2020-01-01"),
+    n = 20
+  )
+
+  cut_gap <- cut_data_by_date(sim, cut_date = 0.8, event_gap = 0.05)
+  cut_no_gap <- cut_data_by_date(sim, cut_date = 0.8, event_gap = 0)
+
+  expect_true(is.data.frame(cut_gap))
+  expect_true(nrow(cut_gap) > 0)
+})

--- a/tests/testthat/test-estimate_mom.R
+++ b/tests/testthat/test-estimate_mom.R
@@ -74,3 +74,13 @@ test_that("estimate_nb_mom handles edge cases", {
   expect_warning(res3 <- estimate_nb_mom(df3), "No data")
   expect_true(is.na(res3$lambda))
 })
+
+test_that("estimate_nb_mom errors on bad input", {
+  expect_error(estimate_nb_mom("not a data frame"), "must be a data frame")
+  expect_error(estimate_nb_mom(data.frame(x = 1)), "events.*tte")
+})
+
+test_that("estimate_nb_mom errors on missing group column", {
+  df <- data.frame(events = c(1, 2), tte = c(1, 1))
+  expect_error(estimate_nb_mom(df, group = "nonexistent"), "not found")
+})

--- a/tests/testthat/test-get_cut_date.R
+++ b/tests/testthat/test-get_cut_date.R
@@ -1,0 +1,180 @@
+test_that("get_cut_date returns planned_calendar when no other criteria", {
+  set.seed(456)
+  enroll_rate <- data.frame(rate = 15, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.6, 0.4)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 2, n = 30)
+
+  result <- get_cut_date(sim_data, planned_calendar = 0.5, event_gap = 0)
+  expect_equal(result, 0.5)
+})
+
+test_that("get_cut_date returns max of multiple criteria", {
+  set.seed(789)
+  enroll_rate <- data.frame(rate = 30, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(1.0, 0.8)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 3, n = 60)
+
+  # Request a calendar time AND a target number of events
+
+  # The result should be the max of the two dates
+  result <- get_cut_date(
+    sim_data, planned_calendar = 0.5,
+    target_events = 100,
+    event_gap = 0
+  )
+
+  # Should be >= the calendar time criterion
+  expect_true(result >= 0.5)
+})
+
+test_that("get_cut_date respects min_date and max_date", {
+  set.seed(101)
+  enroll_rate <- data.frame(rate = 20, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.6, 0.4)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 2, n = 40)
+
+  # With min_date > planned_calendar
+  result <- get_cut_date(sim_data, planned_calendar = 0.3, min_date = 0.5, event_gap = 0)
+  expect_true(result >= 0.5)
+
+  # With max_date limiting the result
+  result2 <- get_cut_date(sim_data, planned_calendar = 5.0, max_date = 2.0, event_gap = 0)
+  expect_true(result2 <= 2.0)
+})
+
+test_that("get_cut_date returns max_date when no criteria", {
+  set.seed(202)
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.5, 0.3)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 2, n = 20)
+
+  # No criteria provided
+  result <- get_cut_date(sim_data, max_date = 3.0)
+  expect_equal(result, 3.0)
+})
+
+test_that("get_cut_date errors when lambda missing for target_info", {
+  set.seed(303)
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.5, 0.3)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 2, n = 20)
+
+  expect_error(
+    get_cut_date(sim_data, target_info = 50),
+    "lambda1 and lambda2 must be provided"
+  )
+})
+
+test_that("get_cut_date handles target_info criterion", {
+  set.seed(404)
+  enroll_rate <- data.frame(rate = 30, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.8, 0.5)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 3, n = 60)
+
+  # Use a modest target info so uniroot can find it
+  result <- get_cut_date(
+    sim_data,
+    target_info = 5,
+    lambda1 = 0.8,
+    lambda2 = 0.5,
+    event_gap = 0,
+    min_date = 0.1,
+    max_date = 3.0
+  )
+
+  expect_true(is.numeric(result))
+  expect_true(result >= 0.1)
+  expect_true(result <= 3.0)
+})
+
+test_that("get_cut_date handles target_events", {
+  set.seed(505)
+  enroll_rate <- data.frame(rate = 20, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.6, 0.4)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 3, n = 40)
+
+  result <- get_cut_date(sim_data, target_events = 10, event_gap = 0)
+  expect_true(is.numeric(result))
+  expect_true(result > 0)
+})
+
+test_that("get_cut_date handles target_completers", {
+  set.seed(606)
+  enroll_rate <- data.frame(rate = 20, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.6, 0.4)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 2, n = 40)
+
+  result <- get_cut_date(sim_data, target_completers = 5)
+  expect_true(is.numeric(result))
+  expect_true(result > 0)
+})
+
+test_that("get_cut_date target_info with already-met info at min_date", {
+  set.seed(707)
+  enroll_rate <- data.frame(rate = 30, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.8, 0.5)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 3, n = 60)
+
+  # Very low target info, should be met immediately
+  result <- get_cut_date(
+    sim_data,
+    target_info = 0.001,
+    lambda1 = 0.8,
+    lambda2 = 0.5,
+    event_gap = 0,
+    min_date = 0.5,
+    max_date = 3.0
+  )
+
+  expect_true(result <= 3.0)
+})
+
+test_that("get_cut_date target_info unreachable returns max_date", {
+  set.seed(808)
+  enroll_rate <- data.frame(rate = 5, duration = 0.5)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.5, 0.3)
+  )
+  sim_data <- nb_sim(enroll_rate, fail_rate, max_followup = 1, n = 5)
+
+  # Extremely high target info, unreachable
+  result <- get_cut_date(
+    sim_data,
+    target_info = 100000,
+    lambda1 = 0.5,
+    lambda2 = 0.3,
+    event_gap = 0,
+    min_date = 0.1,
+    max_date = 1.5
+  )
+
+  expect_equal(result, 1.5)
+})

--- a/tests/testthat/test-gsNBCalendar.R
+++ b/tests/testthat/test-gsNBCalendar.R
@@ -92,3 +92,126 @@ test_that("gsNBCalendar works with custom spending functions", {
 
   expect_s3_class(gs_design, "gsNB")
 })
+
+test_that("summary.gsNB returns gsNBsummary object", {
+  nb_ss <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.9,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  gs_design <- gsNBCalendar(nb_ss, k = 3, analysis_times = c(12, 18, 24))
+
+  s <- summary(gs_design)
+  expect_s3_class(s, "gsNBsummary")
+  expect_true(is.character(s))
+
+  s_collapsed <- paste(s, collapse = " ")
+  expect_true(nchar(s_collapsed) > 0)
+
+  # Should mention key terms
+  expect_true(grepl("negative binomial", s_collapsed, ignore.case = TRUE))
+  expect_true(grepl("0.5", s_collapsed))
+  expect_true(grepl("0.3", s_collapsed))
+})
+
+test_that("print.gsNBsummary prints without error", {
+  nb_ss <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.9,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  gs_design <- gsNBCalendar(nb_ss, k = 2, analysis_times = c(12, 24))
+  s <- summary(gs_design)
+
+  expect_output(print(s))
+})
+
+test_that("toInteger.gsNB rounds final sample size", {
+  nb_ss <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.9,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  gs_design <- gsNBCalendar(nb_ss, k = 2, analysis_times = c(12, 24))
+
+  gs_int <- toInteger(gs_design)
+
+  expect_s3_class(gs_int, "gsNB")
+
+  # Final sample size should be integer (within rounding)
+  k <- gs_int$k
+  expect_equal(gs_int$n_total[k], round(gs_int$n_total[k]))
+
+  # n1 + n2 should equal n_total
+  expect_equal(gs_int$n1[k] + gs_int$n2[k], gs_int$n_total[k])
+})
+
+test_that("toInteger.gsNB respects ratio", {
+  nb_ss <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.9,
+    ratio = 2,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  gs_design <- gsNBCalendar(nb_ss, k = 2, analysis_times = c(12, 24))
+
+  gs_int <- toInteger(gs_design)
+
+  # Final total should be divisible by (ratio + 1) = 3
+  expect_equal(gs_int$n_total[2] %% 3, 0)
+})
+
+test_that("toInteger.gsDesign dispatches correctly", {
+  gs <- gsDesign::gsDesign(k = 2, n.fix = 100, test.type = 2)
+  gs_int <- toInteger(gs)
+  expect_s3_class(gs_int, "gsDesign")
+})
+
+test_that("compute_info_at_time returns positive value", {
+  info <- compute_info_at_time(
+    analysis_time = 12,
+    accrual_rate = 10,
+    accrual_duration = 10,
+    lambda1 = 0.5,
+    lambda2 = 0.3,
+    dispersion = 0.1
+  )
+
+  expect_true(is.numeric(info))
+  expect_true(info > 0)
+})
+
+test_that("compute_info_at_time increases with analysis time", {
+  base_args <- list(
+    accrual_rate = 10,
+    accrual_duration = 10,
+    lambda1 = 0.5,
+    lambda2 = 0.3,
+    dispersion = 0.1
+  )
+
+  info_early <- do.call(compute_info_at_time, c(list(analysis_time = 6), base_args))
+  info_late <- do.call(compute_info_at_time, c(list(analysis_time = 12), base_args))
+
+  expect_true(info_late > info_early)
+})
+
+test_that("gsNBCalendar errors without analysis_times", {
+  nb_ss <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.9,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+
+  expect_error(
+    gsNBCalendar(nb_ss, k = 3),
+    "analysis_times must be provided"
+  )
+})
+
+test_that("gsNBCalendar errors when analysis_times length != k", {
+  nb_ss <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.9,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+
+  expect_error(
+    gsNBCalendar(nb_ss, k = 3, analysis_times = c(12, 24)),
+    "analysis_times must have length k"
+  )
+})

--- a/tests/testthat/test-mutze_test.R
+++ b/tests/testthat/test-mutze_test.R
@@ -19,3 +19,70 @@ test_that("mutze_test handles poisson option", {
   res <- mutze_test(cut, method = "poisson")
   expect_true(grepl("Poisson", res$method))
 })
+
+test_that("mutze_test errors on missing columns", {
+  bad_data <- data.frame(x = 1, y = 2, z = 3)
+  expect_error(mutze_test(bad_data), "treatment.*events.*tte")
+})
+
+test_that("mutze_test errors with no positive follow-up", {
+  df <- data.frame(treatment = c("A", "B"), events = c(0, 0), tte = c(0, 0))
+  expect_error(mutze_test(df), "No rows with positive follow-up")
+})
+
+test_that("mutze_test errors with non-two groups", {
+  df <- data.frame(treatment = c("A", "A", "A"), events = c(1, 2, 3), tte = c(1, 1, 1))
+  expect_error(mutze_test(df), "exactly two treatment groups")
+})
+
+test_that("mutze_test drops zero-tte rows", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(treatment = c("Control", "Experimental"), rate = c(0.5, 0.3))
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 1, n = 20)
+  cut <- cut_data_by_date(sim, cut_date = 0.8)
+
+  # Add a zero-tte row
+  extra <- data.frame(
+    id = 999, treatment = "Control", enroll_time = 0,
+    tte = 0, tte_total = 0, events = 0L
+  )
+  cut_with_zero <- rbind(cut, extra)
+
+  res <- mutze_test(cut_with_zero)
+  expect_true(is.finite(res$estimate))
+})
+
+test_that("mutze_test two-sided p-value", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(treatment = c("Control", "Experimental"), rate = c(0.5, 0.3))
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 1, n = 40)
+  cut <- cut_data_by_date(sim, cut_date = 0.8)
+  res <- mutze_test(cut, sided = 2)
+  expect_equal(res$sided, 2)
+  expect_true(res$p_value >= 0 && res$p_value <= 1)
+})
+
+test_that("mutze_test falls back to Poisson on near-Poisson data", {
+  # Very high theta (near-Poisson) should trigger fallback
+  # nb_sim generates Poisson data (k=0), so theta will be very large
+  enroll_rate <- data.frame(rate = 30, duration = 1)
+  fail_rate <- data.frame(treatment = c("Control", "Experimental"), rate = c(0.5, 0.3))
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 2, n = 60)
+  cut <- cut_data_by_date(sim, cut_date = 1.5)
+
+  res <- mutze_test(cut, poisson_threshold = 1000)
+  # Should get a valid result even if it fell back
+  expect_true(is.finite(res$z))
+})
+
+test_that("print.mutze_test works", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(treatment = c("Control", "Experimental"), rate = c(0.5, 0.3))
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 1, n = 20)
+  cut <- cut_data_by_date(sim, cut_date = 0.8)
+  res <- mutze_test(cut)
+
+  expect_output(print(res), "Mutze Test Results")
+  expect_output(print(res), "Rate Ratio")
+  expect_output(print(res), "Group Summary")
+})

--- a/tests/testthat/test-nb_sim_seasonal.R
+++ b/tests/testthat/test-nb_sim_seasonal.R
@@ -1,0 +1,129 @@
+test_that("nb_sim_seasonal returns correct structure", {
+  enroll_rate <- data.frame(rate = 20 / (5 / 12), duration = 5 / 12)
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = c(0.6, 0.5, 0.4, 0.5, 0.4, 0.3, 0.2, 0.3)
+  )
+  sim <- nb_sim_seasonal(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    max_followup = 1,
+    randomization_start_date = as.Date("2020-01-01"),
+    n = 20
+  )
+
+  expect_s3_class(sim, "nb_sim_seasonal")
+  expect_s3_class(sim, "data.frame")
+
+  # Check required columns
+  expected_cols <- c("id", "treatment", "season", "enroll_time",
+                     "start", "end", "event")
+  expect_true(all(expected_cols %in% names(sim)))
+
+  # All events should be 0 or 1
+
+  expect_true(all(sim$event %in% c(0, 1)))
+
+  # All treatments should be from assigned set
+  expect_true(all(sim$treatment %in% c("Control", "Experimental")))
+
+  # All seasons should be valid
+  expect_true(all(sim$season %in% c("Winter", "Spring", "Summer", "Fall")))
+
+  # Start should be <= end for each row
+  expect_true(all(sim$start <= sim$end + 1e-10))
+})
+
+test_that("nb_sim_seasonal errors without start date", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = rep(0.5, 8)
+  )
+  expect_error(
+    nb_sim_seasonal(enroll_rate, fail_rate, max_followup = 1),
+    "randomization_start_date is required"
+  )
+})
+
+test_that("nb_sim_seasonal handles dispersion", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = c(0.6, 0.5, 0.4, 0.5, 0.4, 0.3, 0.2, 0.3),
+    dispersion = 0.5
+  )
+  sim <- nb_sim_seasonal(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    max_followup = 1,
+    randomization_start_date = as.Date("2020-06-01"),
+    n = 30
+  )
+
+  expect_s3_class(sim, "nb_sim_seasonal")
+  # Should have data for all subjects
+  expect_true(length(unique(sim$id)) == 30)
+})
+
+test_that("nb_sim_seasonal validates inputs", {
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = rep(0.5, 8)
+  )
+
+  expect_error(
+    nb_sim_seasonal(
+      enroll_rate = NULL, fail_rate = fail_rate,
+      max_followup = 1, randomization_start_date = as.Date("2020-01-01")
+    ),
+    "enroll_rate must be a data frame"
+  )
+
+  expect_error(
+    nb_sim_seasonal(
+      enroll_rate = data.frame(rate = 10, duration = 1),
+      fail_rate = NULL,
+      max_followup = 1, randomization_start_date = as.Date("2020-01-01")
+    ),
+    "fail_rate must be a data frame"
+  )
+
+  expect_error(
+    nb_sim_seasonal(
+      enroll_rate = data.frame(rate = 10, duration = 1),
+      fail_rate = fail_rate,
+      max_followup = NULL, randomization_start_date = as.Date("2020-01-01")
+    ),
+    "max_followup must be provided"
+  )
+})
+
+test_that("nb_sim_seasonal handles dropout", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(
+    treatment = rep(c("Control", "Experimental"), each = 4),
+    season = rep(c("Winter", "Spring", "Summer", "Fall"), times = 2),
+    rate = rep(0.5, 8)
+  )
+  dropout_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.1, 0.1),
+    duration = c(1, 1)
+  )
+  sim <- nb_sim_seasonal(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    dropout_rate = dropout_rate,
+    max_followup = 1,
+    randomization_start_date = as.Date("2020-01-01"),
+    n = 30
+  )
+
+  expect_s3_class(sim, "nb_sim_seasonal")
+  expect_true(nrow(sim) > 0)
+})

--- a/tests/testthat/test-sample_size_nbinom.R
+++ b/tests/testthat/test-sample_size_nbinom.R
@@ -234,3 +234,203 @@ test_that("sample_size_nbinom handles vector dropout_rate", {
   expect_true(res_diff$exposure[1] < res_diff$exposure[2])
   expect_true(length(res_diff$exposure) == 2)
 })
+
+test_that("sample_size_nbinom input validation errors", {
+  base <- list(lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1,
+               accrual_rate = 10, accrual_duration = 2, trial_duration = 2)
+
+  # Bad rr0
+  expect_error(do.call(sample_size_nbinom, c(base, rr0 = -1)), "rr0 must be positive")
+
+  # Bad power
+  expect_error(do.call(sample_size_nbinom, c(base, power = 0)), "Power must be between")
+  expect_error(do.call(sample_size_nbinom, c(base, power = 1)), "Power must be between")
+
+  # Bad alpha
+  expect_error(do.call(sample_size_nbinom, c(base, alpha = 0)), "Alpha must be between")
+  expect_error(do.call(sample_size_nbinom, c(base, alpha = 1)), "Alpha must be between")
+
+  # Bad dropout_rate
+  expect_error(do.call(sample_size_nbinom, c(base, dropout_rate = -0.1)), "non-negative")
+  expect_error(do.call(sample_size_nbinom, c(base, list(dropout_rate = c(0.1, 0.1, 0.1)))), "scalar or a vector of length 2")
+
+  # Bad max_followup
+  expect_error(do.call(sample_size_nbinom, c(base, max_followup = 0)), "max_followup must be positive")
+  expect_error(do.call(sample_size_nbinom, c(base, max_followup = -1)), "max_followup must be positive")
+  expect_error(do.call(sample_size_nbinom, c(base, list(max_followup = c(1, 2, 3)))), "scalar or a vector of length 2")
+})
+
+test_that("sample_size_nbinom handles non-inferiority (rr0 != 1)", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.5, rr0 = 1.1, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 2, trial_duration = 2
+  )
+  expect_true(res$n_total > 0)
+  expect_equal(res$inputs$rr0, 1.1)
+})
+
+test_that("sample_size_nbinom handles max_followup with split case", {
+  # max_followup shorter than some follow-up times triggers Case 3 (split)
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 10, trial_duration = 15,
+    max_followup = 8
+  )
+  expect_true(res$n_total > 0)
+  # With max_followup, exposure should be less than without
+  res_no_mf <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 10, trial_duration = 15
+  )
+  expect_true(res$exposure[1] <= res_no_mf$exposure[1])
+})
+
+test_that("sample_size_nbinom handles max_followup all-truncated case", {
+  # Very short max_followup truncates everyone
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 10, trial_duration = 15,
+    max_followup = 2
+  )
+  expect_true(res$n_total > 0)
+  expect_true(res$exposure[1] <= 2)
+})
+
+test_that("sample_size_nbinom handles dropout with max_followup", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 10, trial_duration = 15,
+    dropout_rate = 0.1, max_followup = 8
+  )
+  expect_true(res$n_total > 0)
+})
+
+test_that("print.sample_size_nbinom_result works", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  expect_output(print(res), "Sample size")
+})
+
+test_that("print.sample_size_nbinom_result shows non-inferiority", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.5, rr0 = 1.1, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  expect_output(print(res), "Null hypothesis RR")
+})
+
+test_that("print.sample_size_nbinom_result shows vector dispersion", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = c(0.1, 0.2), power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  expect_output(print(res), "\\(n1\\)")
+})
+
+test_that("print.sample_size_nbinom_result shows dropout", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24,
+    dropout_rate = 0.05
+  )
+  expect_output(print(res), "Dropout rate")
+})
+
+test_that("print shows different dropout rates per group", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24,
+    dropout_rate = c(0.05, 0.10)
+  )
+  expect_output(print(res), "\\(n1\\)")
+})
+
+test_that("print shows event gap info", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24,
+    event_gap = 0.5
+  )
+  expect_output(print(res), "Event gap")
+})
+
+test_that("print shows max_followup", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24,
+    max_followup = 12
+  )
+  expect_output(print(res), "Max follow")
+})
+
+test_that("print shows different exposure per group", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24,
+    dropout_rate = c(0.05, 0.2)
+  )
+  expect_output(print(res), "\\(n1\\)")
+})
+
+test_that("summary.sample_size_nbinom_result returns summary object", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  s <- summary(res)
+  expect_s3_class(s, "sample_size_nbinom_summary")
+  expect_true(is.character(s))
+})
+
+test_that("summary shows non-inferiority rr0", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.5, rr0 = 1.1, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  s <- summary(res)
+  s_text <- paste(s, collapse = " ")
+  expect_true(grepl("null hypothesis RR", s_text))
+})
+
+test_that("summary shows vector dispersion", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = c(0.1, 0.2), power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  s <- summary(res)
+  s_text <- paste(s, collapse = " ")
+  expect_true(grepl("\\(n1\\)", s_text))
+})
+
+test_that("summary shows event gap info", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24,
+    event_gap = 0.5
+  )
+  s <- summary(res)
+  s_text <- paste(s, collapse = " ")
+  expect_true(grepl("Event gap", s_text))
+})
+
+test_that("summary shows different exposure per group", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24,
+    dropout_rate = c(0.05, 0.2)
+  )
+  s <- summary(res)
+  s_text <- paste(s, collapse = " ")
+  expect_true(grepl("\\(n1\\)", s_text))
+})
+
+test_that("print.sample_size_nbinom_summary works", {
+  res <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 20, trial_duration = 24
+  )
+  s <- summary(res)
+  expect_output(print(s), "negative binomial")
+})

--- a/tests/testthat/test-sim_gs_nbinom.R
+++ b/tests/testthat/test-sim_gs_nbinom.R
@@ -1,0 +1,160 @@
+test_that("sim_gs_nbinom runs basic simulation", {
+  set.seed(123)
+  enroll_rate <- data.frame(rate = 10, duration = 3)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.6, 0.4),
+    dispersion = 0.2
+  )
+  dropout_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.05, 0.05),
+    duration = c(6, 6)
+  )
+  design <- sample_size_nbinom(
+    lambda1 = 0.6, lambda2 = 0.4, dispersion = 0.2, power = 0.8,
+    accrual_rate = enroll_rate$rate, accrual_duration = enroll_rate$duration,
+    trial_duration = 6
+  )
+  cuts <- list(
+    list(planned_calendar = 2),
+    list(planned_calendar = 4)
+  )
+  sim_results <- sim_gs_nbinom(
+    n_sims = 2,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    dropout_rate = dropout_rate,
+    max_followup = 4,
+    n_target = 30,
+    design = design,
+    cuts = cuts,
+    seed = TRUE
+  )
+
+  expect_true(is.data.frame(sim_results))
+
+  # Expected columns
+  expected_cols <- c("sim", "analysis", "analysis_time", "n_enrolled",
+                     "n_ctrl", "n_exp", "events_total", "z_stat",
+                     "blinded_info", "unblinded_info",
+                     "info_unblinded_ml", "info_blinded_ml",
+                     "info_unblinded_mom", "info_blinded_mom")
+  expect_true(all(expected_cols %in% names(sim_results)))
+
+  # 2 sims x 2 analyses = 4 rows
+  expect_equal(nrow(sim_results), 4)
+
+  # Sim IDs should be 1 and 2
+  expect_equal(sort(unique(sim_results$sim)), c(1, 2))
+
+  # Analysis IDs should be 1 and 2
+  expect_equal(sort(unique(sim_results$analysis)), c(1, 2))
+
+  # Analysis times should be non-decreasing within each sim
+  for (s in unique(sim_results$sim)) {
+    sub <- sim_results[sim_results$sim == s, ]
+    expect_true(all(diff(sub$analysis_time) >= 0))
+  }
+})
+
+test_that("sim_gs_nbinom errors without design", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.5, 0.3),
+    dispersion = 0.1
+  )
+
+  expect_error(
+    sim_gs_nbinom(
+      n_sims = 1,
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      max_followup = 2,
+      cuts = list(list(planned_calendar = 1))
+    ),
+    "design object must be provided"
+  )
+})
+
+test_that("sim_gs_nbinom errors without cuts or analysis_times", {
+  enroll_rate <- data.frame(rate = 10, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.5, 0.3),
+    dispersion = 0.1
+  )
+  design <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.3, dispersion = 0.1, power = 0.8,
+    accrual_rate = 10, accrual_duration = 1, trial_duration = 3
+  )
+
+  expect_error(
+    sim_gs_nbinom(
+      n_sims = 1,
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      max_followup = 2,
+      design = design
+    ),
+    "Either analysis_times or cuts must be provided"
+  )
+})
+
+test_that("sim_gs_nbinom accepts analysis_times", {
+  set.seed(42)
+  enroll_rate <- data.frame(rate = 10, duration = 3)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.6, 0.4),
+    dispersion = 0.2
+  )
+  design <- sample_size_nbinom(
+    lambda1 = 0.6, lambda2 = 0.4, dispersion = 0.2, power = 0.8,
+    accrual_rate = 10, accrual_duration = 3, trial_duration = 6
+  )
+
+  # Use analysis_times instead of cuts
+  sim_results <- sim_gs_nbinom(
+    n_sims = 2,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    max_followup = 4,
+    n_target = 30,
+    design = design,
+    analysis_times = c(2, 4),
+    seed = TRUE
+  )
+
+  expect_true(is.data.frame(sim_results))
+  expect_equal(nrow(sim_results), 4)
+})
+
+test_that("sim_gs_nbinom is reproducible with seed", {
+  enroll_rate <- data.frame(rate = 10, duration = 2)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.6, 0.4),
+    dispersion = 0.2
+  )
+  design <- sample_size_nbinom(
+    lambda1 = 0.6, lambda2 = 0.4, dispersion = 0.2, power = 0.8,
+    accrual_rate = 10, accrual_duration = 2, trial_duration = 4
+  )
+  cuts <- list(list(planned_calendar = 2), list(planned_calendar = 4))
+
+  set.seed(42)
+  res1 <- sim_gs_nbinom(
+    n_sims = 3, enroll_rate = enroll_rate, fail_rate = fail_rate,
+    max_followup = 3, n_target = 20, design = design, cuts = cuts, seed = TRUE
+  )
+
+  set.seed(42)
+  res2 <- sim_gs_nbinom(
+    n_sims = 3, enroll_rate = enroll_rate, fail_rate = fail_rate,
+    max_followup = 3, n_target = 20, design = design, cuts = cuts, seed = TRUE
+  )
+
+  expect_identical(res1, res2)
+})

--- a/tests/testthat/test-sim_ssr_nbinom.R
+++ b/tests/testthat/test-sim_ssr_nbinom.R
@@ -150,3 +150,562 @@ test_that("check_gs_bound accepts explicit information column", {
   expect_s3_class(res_custom, "data.frame")
   expect_equal(nrow(res_custom), nrow(sim_df))
 })
+
+test_that("sim_ssr_nbinom errors on bad design", {
+  expect_error(
+    sim_ssr_nbinom(
+      n_sims = 1,
+      enroll_rate = data.frame(rate = 10, duration = 4),
+      fail_rate = data.frame(treatment = c("Control", "Experimental"), rate = c(0.5, 0.3), dispersion = 0.2),
+      dropout_rate = NULL,
+      max_followup = 4,
+      design = list(k = 2),
+      strategies = "No adaptation"
+    ),
+    "gsNB"
+  )
+})
+
+test_that("sim_ssr_nbinom errors on bad strategies", {
+  args <- setup_ssr_args()
+  expect_error(
+    sim_ssr_nbinom(
+      n_sims = 1,
+      enroll_rate = args$enroll_rate,
+      fail_rate = args$fail_rate,
+      dropout_rate = args$dropout_rate,
+      max_followup = 4,
+      design = args$design,
+      strategies = "Invalid Strategy"
+    ),
+    "strategies must be chosen from"
+  )
+})
+
+test_that("sim_ssr_nbinom works with Unblinded SSR strategy", {
+  args <- setup_ssr_args()
+
+  res <- sim_ssr_nbinom(
+    n_sims = 2,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = c("No adaptation", "Unblinded SSR"),
+    n_max = 80,
+    seed = 999
+  )
+
+  expect_s3_class(res, "sim_ssr_nbinom")
+  expect_true(nrow(res$trial_results) > 0)
+})
+
+test_that("summarize_ssr_sim works without by argument", {
+  args <- setup_ssr_args()
+
+  res <- sim_ssr_nbinom(
+    n_sims = 3,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = "No adaptation",
+    n_max = 60,
+    seed = 111
+  )
+
+  sm <- summarize_ssr_sim(res)
+
+  expect_s3_class(sm$trial_summary, "data.frame")
+  expect_s3_class(sm$analysis_summary, "data.frame")
+  expect_true(nrow(sm$trial_summary) > 0)
+})
+
+test_that("sim_ssr_nbinom handles ignore_futility", {
+  args <- setup_ssr_args()
+
+  res <- sim_ssr_nbinom(
+    n_sims = 2,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = "No adaptation",
+    n_max = 60,
+    ignore_futility = TRUE,
+    seed = 222
+  )
+
+  expect_s3_class(res, "sim_ssr_nbinom")
+  expect_true(nrow(res$trial_results) > 0)
+})
+
+test_that("sim_ssr_nbinom handles metadata", {
+  args <- setup_ssr_args()
+
+  meta <- data.frame(scenario = "base", label = "test")
+  res <- sim_ssr_nbinom(
+    n_sims = 2,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = "No adaptation",
+    n_max = 60,
+    metadata = meta,
+    seed = 333
+  )
+
+  expect_s3_class(res, "sim_ssr_nbinom")
+  expect_true("scenario" %in% names(res$trial_results))
+  expect_true("label" %in% names(res$trial_results))
+})
+
+test_that("sim_ssr_nbinom handles different bound_info", {
+  args <- setup_ssr_args()
+
+  for (bi in c("blinded_ml", "unblinded_mom", "blinded_mom")) {
+    res <- sim_ssr_nbinom(
+      n_sims = 2,
+      enroll_rate = args$enroll_rate,
+      fail_rate = args$fail_rate,
+      dropout_rate = args$dropout_rate,
+      max_followup = 4,
+      design = args$design,
+      strategies = "No adaptation",
+      n_max = 60,
+      bound_info = bi,
+      seed = 444
+    )
+    expect_s3_class(res, "sim_ssr_nbinom")
+  }
+})
+
+test_that("sim_ssr_nbinom handles all three strategies", {
+  args <- setup_ssr_args()
+
+  res <- sim_ssr_nbinom(
+    n_sims = 2,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = c("No adaptation", "Blinded SSR", "Unblinded SSR"),
+    n_max = 80,
+    seed = 555
+  )
+
+  expect_s3_class(res, "sim_ssr_nbinom")
+  # Should have results for all 3 strategies
+  expect_true(all(c("No adaptation", "Blinded SSR", "Unblinded SSR") %in% res$trial_results$strategy))
+})
+
+# --- Internal helper tests ---
+
+test_that(".ssr_metadata_df handles named list", {
+  result <- gsDesignNB:::.ssr_metadata_df(list(scenario = "A", label = "test"))
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 1)
+  expect_equal(result$scenario, "A")
+})
+
+test_that(".ssr_metadata_df errors on multi-row data frame", {
+  expect_error(
+    gsDesignNB:::.ssr_metadata_df(data.frame(scenario = c("A", "B"))),
+    "exactly one row"
+  )
+})
+
+test_that(".ssr_metadata_df errors on bad input", {
+  expect_error(
+    gsDesignNB:::.ssr_metadata_df("bad input"),
+    "named list or one-row data frame"
+  )
+})
+
+test_that(".ssr_select_info falls back to unblinded_ml", {
+  metrics <- list(
+    info_unblinded_ml = 50,
+    info_blinded_ml = NA_real_,
+    info_unblinded_mom = 0,
+    info_blinded_mom = -1
+  )
+
+  # blinded_ml is NA -> should fall back
+
+expect_equal(gsDesignNB:::.ssr_select_info(metrics, "blinded_ml"), 50)
+  # unblinded_mom is 0 -> should fall back
+  expect_equal(gsDesignNB:::.ssr_select_info(metrics, "unblinded_mom"), 50)
+  # blinded_mom is negative -> should fall back
+  expect_equal(gsDesignNB:::.ssr_select_info(metrics, "blinded_mom"), 50)
+  # unblinded_ml is valid -> should return directly
+  expect_equal(gsDesignNB:::.ssr_select_info(metrics, "unblinded_ml"), 50)
+})
+
+test_that(".ssr_stage_label_from_suffix works", {
+  expect_equal(gsDesignNB:::.ssr_stage_label_from_suffix("final"), "Final")
+  expect_equal(gsDesignNB:::.ssr_stage_label_from_suffix("ia1"), "IA1")
+  expect_equal(gsDesignNB:::.ssr_stage_label_from_suffix("ia2"), "IA2")
+})
+
+test_that(".ssr_stage_suffixes_from_trial_results extracts suffixes", {
+  dt <- data.table::data.table(if_ia1 = 0.5, if_ia2 = 0.8, if_final = 1.0, x = 1)
+  result <- gsDesignNB:::.ssr_stage_suffixes_from_trial_results(dt)
+  expect_equal(sort(result), c("final", "ia1", "ia2"))
+})
+
+test_that(".ssr_dynamic_bounds returns bounds", {
+  design <- gsDesign::gsDesign(k = 3, test.type = 4, n.fix = 100,
+                                timing = c(0.33, 0.67, 1))
+
+  bounds <- gsDesignNB:::.ssr_dynamic_bounds(
+    analysis_index = 1,
+    n_analyses = 3,
+    observed_if = c(0.35, NA, NA),
+    planned_timing = c(0.33, 0.67, 1),
+    target_info = 100,
+    design = design
+  )
+
+  expect_true(is.finite(bounds$upper_bound))
+  expect_true(is.finite(bounds$lower_bound))
+})
+
+test_that(".ssr_dynamic_bounds handles final analysis", {
+  design <- gsDesign::gsDesign(k = 2, test.type = 4, n.fix = 100,
+                                timing = c(0.5, 1))
+
+  bounds <- gsDesignNB:::.ssr_dynamic_bounds(
+    analysis_index = 2,
+    n_analyses = 2,
+    observed_if = c(0.5, 1.0),
+    planned_timing = c(0.5, 1),
+    target_info = 100,
+    design = design
+  )
+
+  expect_true(is.finite(bounds$upper_bound))
+  expect_true(is.finite(bounds$lower_bound))
+})
+
+test_that(".ssr_dynamic_bounds returns NA on bad input", {
+  design <- gsDesign::gsDesign(k = 2, test.type = 4, n.fix = 100,
+                                timing = c(0.5, 1))
+
+  bounds <- gsDesignNB:::.ssr_dynamic_bounds(
+    analysis_index = 1,
+    n_analyses = 2,
+    observed_if = c(NA_real_, NA_real_),
+    planned_timing = c(0.5, 1),
+    target_info = 100,
+    design = design
+  )
+
+  expect_true(is.na(bounds$upper_bound))
+  expect_true(is.na(bounds$lower_bound))
+})
+
+test_that(".ssr_extract_info_metrics returns all info types", {
+  enroll_rate <- data.frame(rate = 50, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.5, 0.3)
+  )
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 3, n = 100)
+  cut <- cut_data_by_date(sim, cut_date = 2)
+
+  metrics <- gsDesignNB:::.ssr_extract_info_metrics(
+    cut_data = cut,
+    ratio_plan = 1,
+    lambda1_plan = 0.5,
+    lambda2_plan = 0.3,
+    event_gap = 0
+  )
+
+  expect_true(is.list(metrics))
+  expect_true(all(c("z_value", "info_unblinded_ml", "info_blinded_ml") %in% names(metrics)))
+  expect_true(is.finite(metrics$z_value))
+  expect_true(is.finite(metrics$info_unblinded_ml))
+})
+
+test_that(".ssr_extract_info_metrics handles insufficient data", {
+  cut <- data.frame(
+    id = 1:2, treatment = c("Control", "Experimental"),
+    events = c(0, 0), tte = c(0.01, 0.01), enroll_time = c(0, 0)
+  )
+
+  metrics <- gsDesignNB:::.ssr_extract_info_metrics(
+    cut_data = cut,
+    ratio_plan = 1,
+    lambda1_plan = 0.5,
+    lambda2_plan = 0.3,
+    event_gap = 0
+  )
+
+  expect_true(is.na(metrics$z_value))
+})
+
+test_that(".ssr_long_from_trial_results reshapes correctly", {
+  args <- setup_ssr_args()
+  res <- sim_ssr_nbinom(
+    n_sims = 2,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = "No adaptation",
+    n_max = 60,
+    seed = 666
+  )
+
+  long <- gsDesignNB:::.ssr_long_from_trial_results(res$trial_results)
+  expect_true(is.data.frame(long))
+  expect_true(nrow(long) > 0)
+  expect_true(all(c("analysis", "analysis_stage", "analysis_time",
+                     "z_value", "info_value", "info_fraction",
+                     "cross_upper", "cross_lower") %in% names(long)))
+  # For k=3 design: ia1, ia2, final -> 3 rows per sim per strategy
+  expect_equal(nrow(long), 2 * 3)
+})
+
+test_that("summarize_ssr_sim works on raw trial_results data frame", {
+  args <- setup_ssr_args()
+  res <- sim_ssr_nbinom(
+    n_sims = 3,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = "No adaptation",
+    n_max = 60,
+    seed = 777
+  )
+
+  # Pass raw trial_results data frame, not the sim_ssr_nbinom object
+  sm <- summarize_ssr_sim(res$trial_results)
+  expect_true(is.data.frame(sm$trial_summary))
+  expect_true(nrow(sm$trial_summary) > 0)
+})
+
+test_that("summarize_ssr_sim works with by = NULL", {
+  args <- setup_ssr_args()
+  res <- sim_ssr_nbinom(
+    n_sims = 3,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = "No adaptation",
+    n_max = 60,
+    seed = 888
+  )
+
+  sm <- summarize_ssr_sim(res, by = "nonexistent_col")
+  expect_true(is.data.frame(sm$trial_summary))
+  expect_true(nrow(sm$trial_summary) == 1)
+})
+
+test_that("sim_ssr_nbinom errors on design with k < 2", {
+  # Create a gsNB-like object with k=1 to trigger the error
+  fake_design <- list(k = 1)
+  class(fake_design) <- c("gsNB", "gsDesign")
+
+  expect_error(
+    sim_ssr_nbinom(
+      n_sims = 1,
+      enroll_rate = data.frame(rate = 10, duration = 4),
+      fail_rate = data.frame(treatment = c("Control", "Experimental"), rate = c(0.5, 0.3)),
+      max_followup = 4,
+      design = fake_design,
+      strategies = "No adaptation"
+    ),
+    "at least one interim"
+  )
+})
+
+test_that("sim_ssr_nbinom errors on bad adapt_analysis", {
+  args <- setup_ssr_args()
+
+  expect_error(
+    sim_ssr_nbinom(
+      n_sims = 1,
+      enroll_rate = args$enroll_rate,
+      fail_rate = args$fail_rate,
+      max_followup = 4,
+      design = args$design,
+      strategies = "No adaptation",
+      adapt_analysis = 10
+    ),
+    "adapt_analysis must identify an interim"
+  )
+})
+
+test_that("sim_ssr_nbinom uses event_gap from design inputs", {
+  fixed_design <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.35, dispersion = 0.3,
+    power = 0.8, alpha = 0.025,
+    accrual_rate = 10, accrual_duration = 4, trial_duration = 8,
+    max_followup = 4, event_gap = 0.5
+  )
+  gs_design <- gsNBCalendar(
+    fixed_design, k = 2, test.type = 4, alpha = 0.025,
+    analysis_times = c(5, 8)
+  )
+
+  res <- sim_ssr_nbinom(
+    n_sims = 2,
+    enroll_rate = data.frame(rate = 10, duration = 4),
+    fail_rate = data.frame(treatment = c("Control", "Experimental"),
+                           rate = c(0.5, 0.35), dispersion = 0.3),
+    max_followup = 4,
+    design = gs_design,
+    strategies = "No adaptation",
+    seed = 1234
+  )
+
+  # event_gap should be extracted from design
+  expect_equal(res$settings$event_gap, 0.5)
+})
+
+test_that("sim_ssr_nbinom with adapt parameters triggers adaptation checks", {
+  args <- setup_ssr_args()
+
+  res <- sim_ssr_nbinom(
+    n_sims = 3,
+    enroll_rate = args$enroll_rate,
+    fail_rate = args$fail_rate,
+    dropout_rate = args$dropout_rate,
+    max_followup = 4,
+    design = args$design,
+    strategies = c("Blinded SSR", "Unblinded SSR"),
+    n_max = 100,
+    adapt_analysis = 2,
+    max_enrollment_frac_for_adapt = 0.95,
+    min_months_to_close_for_adapt = 0,
+    analysis_lag_months = 0.5,
+    seed = 2345
+  )
+
+  expect_s3_class(res, "sim_ssr_nbinom")
+  tr <- res$trial_results
+  # Should have adapt-related columns
+  expect_true("adapt_allowed" %in% names(tr))
+  expect_true("adapt_applied" %in% names(tr))
+  # adapt_analysis = 2 means ia2 columns should exist
+  expect_true("ia2_adapt_cut_time" %in% names(tr))
+})
+
+test_that(".ssr_dynamic_bounds handles non-monotone timing", {
+  design <- gsDesign::gsDesign(k = 3, test.type = 4, n.fix = 100,
+                                timing = c(0.33, 0.67, 1))
+
+  # Decreasing observed IFs should trigger monotonicity correction
+  bounds <- gsDesignNB:::.ssr_dynamic_bounds(
+    analysis_index = 2,
+    n_analyses = 3,
+    observed_if = c(0.5, 0.4, NA),
+    planned_timing = c(0.33, 0.67, 1),
+    target_info = 100,
+    design = design
+  )
+
+  # Even after correction, should produce numeric bounds (may be NA if gsDesign fails)
+  expect_true(is.numeric(bounds$upper_bound))
+  expect_true(is.numeric(bounds$lower_bound))
+})
+
+test_that(".ssr_extract_info_metrics computes all four info types", {
+  set.seed(42)
+  enroll_rate <- data.frame(rate = 50, duration = 1)
+  fail_rate <- data.frame(
+    treatment = c("Control", "Experimental"),
+    rate = c(0.6, 0.3),
+    dispersion = 0.3
+  )
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 3, n = 100)
+  cut <- cut_data_by_date(sim, cut_date = 2)
+
+  metrics <- gsDesignNB:::.ssr_extract_info_metrics(
+    cut_data = cut,
+    ratio_plan = 1,
+    lambda1_plan = 0.6,
+    lambda2_plan = 0.3,
+    event_gap = 0
+  )
+
+  # Should have all fields
+  expect_true(is.finite(metrics$info_unblinded_ml))
+  expect_true(is.finite(metrics$info_blinded_ml))
+  # MoM estimates may or may not be finite depending on data
+  expect_true("info_unblinded_mom" %in% names(metrics))
+  expect_true("info_blinded_mom" %in% names(metrics))
+})
+
+test_that(".ssr_long_from_trial_results handles empty suffixes", {
+  dt <- data.frame(sim = 1, strategy = "No adaptation", reject = FALSE)
+  result <- gsDesignNB:::.ssr_long_from_trial_results(dt)
+  expect_equal(nrow(result), 0)
+})
+
+test_that(".ssr_long_from_trial_results handles missing required columns", {
+  # Create a data frame that has if_ columns but not all required stage cols
+  dt <- data.frame(
+    sim = 1, strategy = "No adaptation", reject = FALSE,
+    if_ia1 = 0.5, if_final = 1.0,
+    ia1_time = 5, final_time = 10
+  )
+  result <- gsDesignNB:::.ssr_long_from_trial_results(dt)
+  # Should return empty or skip incomplete stages
+  expect_true(nrow(result) == 0)
+})
+
+test_that("sim_ssr_nbinom SSR adaptation is applied with favorable design", {
+  # Use a design with much lower power so SSR re-estimation
+  # will want to increase the sample size
+  fixed_design <- sample_size_nbinom(
+    lambda1 = 0.5, lambda2 = 0.45, dispersion = 0.4,
+    power = 0.8, alpha = 0.025,
+    accrual_rate = 8, accrual_duration = 6, trial_duration = 12,
+    max_followup = 6
+  )
+  gs_design <- gsNBCalendar(
+    fixed_design, k = 2, test.type = 4, alpha = 0.025,
+    sfu = sfHSD, sfupar = -2, sfl = sfHSD, sflpar = 1,
+    analysis_times = c(6, 12)
+  )
+
+  # Simulate with higher true rates so SSR will re-estimate higher N
+  res <- sim_ssr_nbinom(
+    n_sims = 5,
+    enroll_rate = data.frame(rate = 8, duration = 6),
+    fail_rate = data.frame(
+      treatment = c("Control", "Experimental"),
+      rate = c(0.5, 0.45), dispersion = 0.4
+    ),
+    dropout_rate = data.frame(
+      treatment = c("Control", "Experimental"),
+      rate = c(0.05, 0.05), duration = c(12, 12)
+    ),
+    max_followup = 6,
+    design = gs_design,
+    strategies = c("Blinded SSR", "Unblinded SSR"),
+    n_max = 200,
+    max_enrollment_frac_for_adapt = 1.0,
+    min_months_to_close_for_adapt = 0,
+    seed = 9999
+  )
+
+  expect_s3_class(res, "sim_ssr_nbinom")
+  tr <- res$trial_results
+  expect_true("adapt_allowed" %in% names(tr))
+  # At least some sims should have adaptation allowed
+  expect_true(any(tr$adapt_allowed))
+})

--- a/tests/testthat/test-summarize_gs_sim.R
+++ b/tests/testthat/test-summarize_gs_sim.R
@@ -1,0 +1,80 @@
+test_that("summarize_gs_sim returns correct structure", {
+  # Create mock data that check_gs_bound would produce
+  sim_df <- data.frame(
+    sim = c(1, 1, 2, 2, 3, 3),
+    analysis = c(1, 2, 1, 2, 1, 2),
+    z_stat = c(2.5, NA, -0.5, 2.1, 1.0, 1.5),
+    blinded_info = c(40, 80, 40, 80, 40, 80),
+    unblinded_info = c(40, 80, 40, 80, 40, 80),
+    n_enrolled = c(30, 60, 30, 60, 30, 60),
+    events_total = c(12, 25, 10, 22, 11, 20),
+    cross_upper = c(TRUE, FALSE, FALSE, TRUE, FALSE, FALSE),
+    cross_lower = c(FALSE, FALSE, FALSE, FALSE, FALSE, TRUE)
+  )
+
+  result <- summarize_gs_sim(sim_df)
+
+  expect_true(is.list(result))
+  expect_true(all(c("n_sim", "power", "futility", "analysis_summary") %in% names(result)))
+
+  # 3 simulations
+ expect_equal(result$n_sim, 3)
+
+  # Power: sims 1 and 2 cross upper
+  expect_equal(result$power, 2 / 3)
+
+  # Futility: sim 3 crosses lower but not upper
+  expect_equal(result$futility, 1 / 3)
+
+  # Analysis summary should be a data frame with 2 rows
+  expect_true(is.data.frame(result$analysis_summary))
+  expect_equal(nrow(result$analysis_summary), 2)
+
+  # Check cumulative probability column exists
+  expect_true("cum_prob_upper" %in% names(result$analysis_summary))
+})
+
+test_that("summarize_gs_sim errors without required columns", {
+  bad_df <- data.frame(sim = 1, analysis = 1, z_stat = 1.5)
+
+  expect_error(
+    summarize_gs_sim(bad_df),
+    "cross_upper.*cross_lower"
+  )
+})
+
+test_that("summarize_gs_sim handles all successes", {
+  sim_df <- data.frame(
+    sim = c(1, 1, 2, 2),
+    analysis = c(1, 2, 1, 2),
+    z_stat = c(3.0, NA, 3.5, NA),
+    blinded_info = c(40, 80, 40, 80),
+    unblinded_info = c(40, 80, 40, 80),
+    n_enrolled = c(30, 60, 30, 60),
+    events_total = c(15, 25, 15, 25),
+    cross_upper = c(TRUE, FALSE, TRUE, FALSE),
+    cross_lower = c(FALSE, FALSE, FALSE, FALSE)
+  )
+
+  result <- summarize_gs_sim(sim_df)
+  expect_equal(result$power, 1.0)
+  expect_equal(result$futility, 0.0)
+})
+
+test_that("summarize_gs_sim handles no crossings", {
+  sim_df <- data.frame(
+    sim = c(1, 1),
+    analysis = c(1, 2),
+    z_stat = c(0.5, 1.0),
+    blinded_info = c(40, 80),
+    unblinded_info = c(40, 80),
+    n_enrolled = c(30, 60),
+    events_total = c(10, 20),
+    cross_upper = c(FALSE, FALSE),
+    cross_lower = c(FALSE, FALSE)
+  )
+
+  result <- summarize_gs_sim(sim_df)
+  expect_equal(result$power, 0.0)
+  expect_equal(result$futility, 0.0)
+})

--- a/tests/testthat/test-unblinded_ssr.R
+++ b/tests/testthat/test-unblinded_ssr.R
@@ -1,0 +1,119 @@
+test_that("unblinded_ssr estimates parameters and re-estimates sample size", {
+
+  # Simulate data with known parameters
+  enroll_rate <- data.frame(rate = 100, duration = 1)
+  fail_rate <- data.frame(treatment = c("Control", "Experimental"),
+                          rate = c(0.5, 0.3))
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 10, n = 200,
+                block = c("Control", "Experimental"))
+
+  cut <- cut_data_by_date(sim, cut_date = 5)
+
+  res <- unblinded_ssr(
+    cut,
+    ratio = 1,
+    lambda1_planning = 0.5,
+    lambda2_planning = 0.3,
+    power = 0.8,
+    alpha = 0.025,
+    accrual_rate = 100,
+    accrual_duration = 1,
+    trial_duration = 10
+  )
+
+  # Check output names
+  expect_true(all(c("n_total_unblinded", "dispersion_unblinded",
+                     "lambda1_unblinded", "lambda2_unblinded",
+                     "info_fraction", "unblinded_info", "target_info") %in% names(res)))
+
+  # Re-estimated control rate should be near 0.5
+  expect_true(res$lambda1_unblinded > 0.2 && res$lambda1_unblinded < 1.0)
+
+  # Re-estimated experimental rate should be near 0.3
+  expect_true(res$lambda2_unblinded > 0.1 && res$lambda2_unblinded < 0.8)
+
+  # Dispersion should be near 0 for Poisson data
+
+  expect_true(res$dispersion_unblinded >= 0 && res$dispersion_unblinded < 0.5)
+
+  # Sample size should be positive
+  expect_true(res$n_total_unblinded > 0)
+
+  # Information fraction should be positive
+  expect_true(res$info_fraction > 0)
+  expect_true(res$unblinded_info > 0)
+  expect_true(res$target_info > 0)
+})
+
+test_that("unblinded_ssr preserves planned effect size", {
+  # Generate data where control rate is lower than planned
+  enroll_rate <- data.frame(rate = 100, duration = 1)
+  fail_rate <- data.frame(treatment = c("Control", "Experimental"),
+                          rate = c(0.3, 0.18))
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 10, n = 200,
+                block = c("Control", "Experimental"))
+
+  cut <- cut_data_by_date(sim, cut_date = 5)
+
+  # Planning assumed higher rates
+  res <- unblinded_ssr(
+    cut,
+    ratio = 1,
+    lambda1_planning = 0.5,
+    lambda2_planning = 0.3,
+    power = 0.8,
+    alpha = 0.025,
+    accrual_rate = 100,
+    accrual_duration = 1,
+    trial_duration = 10
+  )
+
+  # The planned rate ratio is 0.3/0.5 = 0.6
+
+  # The re-estimated lambda2 should reflect the planned RR applied to observed control rate
+  # lambda2_calc = lambda1_est * (0.3/0.5)
+  # But the RETURNED lambda2_unblinded is the OBSERVED one (not the calc one)
+  expect_true(res$n_total_unblinded > 0)
+})
+
+test_that("unblinded_ssr handles unequal allocation", {
+  enroll_rate <- data.frame(rate = 100, duration = 1)
+  fail_rate <- data.frame(treatment = c("Control", "Experimental"),
+                          rate = c(0.5, 0.3))
+  sim <- nb_sim(enroll_rate, fail_rate, max_followup = 10, n = 200,
+                block = c("Control", "Experimental", "Experimental"))
+
+  cut <- cut_data_by_date(sim, cut_date = 5)
+
+  res <- unblinded_ssr(
+    cut,
+    ratio = 2,
+    lambda1_planning = 0.5,
+    lambda2_planning = 0.3,
+    power = 0.8,
+    alpha = 0.025,
+    accrual_rate = 100,
+    accrual_duration = 1,
+    trial_duration = 10
+  )
+
+  expect_true(res$n_total_unblinded > 0)
+  expect_true(res$unblinded_info > 0)
+})
+
+test_that("unblinded_ssr errors on bad data", {
+  bad_data <- data.frame(events = c(0), tte = c(0.1), treatment = c("Control"))
+  expect_error(
+    unblinded_ssr(
+      bad_data,
+      ratio = 1,
+      lambda1_planning = 0.5,
+      lambda2_planning = 0.3,
+      power = 0.8,
+      alpha = 0.025,
+      accrual_rate = 10,
+      accrual_duration = 1,
+      trial_duration = 10
+    )
+  )
+})


### PR DESCRIPTION
- Add 6 new test files: check_gs_bound, get_cut_date, nb_sim_seasonal, sim_gs_nbinom, summarize_gs_sim, unblinded_ssr
- Expand 8 existing test files: calculate_blinded_info, cut_completers, cut_data_by_date, estimate_mom, gsNBCalendar, mutze_test, sample_size_nbinom, sim_ssr_nbinom
- Add nocov markers to untestable interactive functions (preview_pkgdown_site, run_ssr_shiny)
- 422 passing tests, 95.2% overall coverage
- sim_ssr_nbinom.R coverage: 81% -> 97.2%