### PR TITLE
Update Codecov action for coverage workflow

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -36,7 +36,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      - uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- update the pinned Codecov GitHub Action from v6 to v7 for the coverage workflow
- keep the existing coverage generation and upload settings unchanged

## Context
The post-merge main run failed after tests passed because Codecov CLI signature verification could not import/check the uploader public key. Codecov Action v7 updates the wrapper key-fetch path.

## Testing
- workflow-only change; validating via GitHub Actions